### PR TITLE
removed body-parser dependency

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,6 @@
 const express = require("express"),
     flash = require("connect-flash"),
     app = express(),
-    bodyParser = require("body-parser"),
     mongoose = require("mongoose"),
     request = require("request"),
     passport = require("passport"),
@@ -31,7 +30,7 @@ var Campground = require("./models/campground"), //require Campground modules fo
 //========================End of Creating Database============================================//
 
 
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(express.urlencoded({ extended: true }));
 app.set("view engine", "ejs");
 app.use(express.static(__dirname + "/public")); //use of css file
 app.use(methodOverride("_method")); //this method is used for PUT method in edit.ejs

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "author": "Manish Gupta",
   "license": "ISC",
   "dependencies": {
-    "body-parser": "^1.19.0",
     "connect-flash": "^0.1.1",
     "ejs": "^2.6.2",
     "express": "^4.17.1",


### PR DESCRIPTION
in the newer version of the express.js (since last two years) **body-parser** dependency is internally installed. So there is no need of requiring and install it twice.

Happy coding : )
